### PR TITLE
adjust renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,39 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "timezone": "Asia/Tokyo",
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 2,
+  "schedule": [
+    "before 3am on monday"
+  ],
+  "mergeType": "squash",
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "pub"
+      ],
+      "groupName": "pub packages",
+      "automerge": true,
+      "automergeType": "pr",
+      "mergeType": "squash",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    },
+    {
+      "matchPackageManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to better control and automate dependency updates, particularly for scheduling, grouping, and merging strategies.

Configuration improvements:

* Set the timezone to `Asia/Tokyo` and scheduled Renovate to run before 3am on Mondays for more predictable update timing.
* Limited the number of concurrent pull requests to 10 and the hourly limit to 2 to reduce noise and manage update flow.

Dependency update strategy:

* Set the `rangeStrategy` to `bump` and the default merge type to `squash` for cleaner commit history.
* Added package rules to group and automerge minor and patch updates for `pub` packages, and to group but not automerge minor and patch updates for `github-actions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係管理の自動化設定を更新しました。スケジュール、マージ戦略、および自動マージルールを調整し、開発プロセスの効率化を図りました。

**注記:** このリリースはユーザーに直接影響を与えるものではありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->