### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -2,7 +2,7 @@ name: Build Check
 
 on:
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ "main", "develop" ]
 
 concurrency:
   group: build-check-${{ github.ref }}

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -18,9 +18,6 @@ jobs:
 
       - name: Set up Flutter (mise)
         uses: jdx/mise-action@v3
-        with:
-          # Use the repository's mise.toml to install the specified Flutter/sdk/tooling
-          file: mise.toml
 
       - name: Cache pub and .dart_tool
         uses: actions/cache@v4

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Format check
         # Fail if any files need formatting
-        run: flutter format --set-exit-if-changed .
+        run: dart format --set-exit-if-changed .
 
       - name: Static analysis
         run: flutter analyze --no-fatal-infos

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Flutter (mise)
-        uses: jdx/mise-action@v1
+        uses: jdx/mise-action@v3
         with:
           # Use the repository's mise.toml to install the specified Flutter/sdk/tooling
           file: mise.toml

--- a/android/version.properties
+++ b/android/version.properties
@@ -1,3 +1,3 @@
-flutter.minSdkVersion=21
+flutter.minSdkVersion=23
 flutter.targetSdkVersion=34
 flutter.compileSdkVersion=34


### PR DESCRIPTION
This pull request updates the build check workflow to only run on pull requests targeting the `main` and `develop` branches, instead of `main` and `master`.

Workflow configuration update:

* [`.github/workflows/build-check.yml`](diffhunk://#diff-e667cbf8e98c5f2339128886eb5203cc3e3cfc6452374cdf97af98c92b2485efL5-R5): Changed the list of branches that trigger the build check workflow from `main` and `master` to `main` and `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * CI/CDワークフローを更新し、ビルドプロセスを改善しました。開発ブランチへのPRに対応し、フォーマットチェックを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->