### PR TITLE
fix: flutter sdk path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "dart.getFlutterSdkCommand": {
+        "executable": "mise",
+        "args": [
+            "where",
+            "flutter"
+        ]
+    }
+}


### PR DESCRIPTION
This pull request introduces a new VS Code configuration to improve how the Flutter SDK is located in the development environment.

Development environment configuration:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R9): Added a custom command for `dart.getFlutterSdkCommand` to use the `mise` tool for locating the Flutter SDK, enhancing compatibility and flexibility for developers using VS Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境の設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->